### PR TITLE
Mount tmpfs on /scratch

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -185,6 +185,9 @@ func (m *Machine) CreateImage(path string, size int64) error {
 
 func (m *Machine) generateFstab(w *writerhelper.WriterHelper) {
 	fstab := []string{"# Generated fstab file by fakemachine"}
+
+	fstab = append(fstab, "none /scratch tmpfs size=95% 0 0")
+
 	for _, point := range m.mounts {
 		fstab = append(fstab,
 			fmt.Sprintf("%s %s 9p trans=virtio,version=9p2000.L 0 0",

--- a/machine_test.go
+++ b/machine_test.go
@@ -38,3 +38,15 @@ func TestImage(t *testing.T) {
 		t.Fatalf("Test for the virtual image device failed with %d", exitcode)
 	}
 }
+
+func TestScratchTmp(t *testing.T) {
+	m := NewMachine()
+
+	m.Command = "mountpoint /scratch"
+
+	exitcode := m.Run()
+
+	if exitcode != 0 {
+		t.Fatalf("Test for tmpfs mount on scratch failed with %d", exitcode)
+	}
+}


### PR DESCRIPTION
The rootfs stays on the initramfs which is limited to 50% of the memory
size to allow usage of data mount a tmpfs on /scratch with a maximum
size of 95% of memory (going from 1G to 1.9G of allowed space usage with
the default 2 Gigabyte of memory).

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>